### PR TITLE
Remove broken dependencies

### DIFF
--- a/paradox.el
+++ b/paradox.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/Bruce-Connor/paradox
 ;; Version: 1.2.3
 ;; Keywords: package packages mode-line
-;; Package-Requires: ((emacs "24.1") (tabulated-list) (package "1.0") (dash "2.6.0") (cl-lib "0.5") (json "1.3"))
+;; Package-Requires: ((emacs "24.1") (dash "2.6.0") (cl-lib "0.5") (json "1.3"))
 ;; Prefix: paradox
 ;; Separator: -
 
@@ -1092,7 +1092,8 @@ Return value is always a list.
              ;; Anything else gets interpreted.
              (when (search-forward-regexp "^Link: .*<\\([^>]+\\)>; rel=\"next\"" nil t)
                (setq next (match-string-no-properties 1)))
-             (search-forward-regexp "^?$")
+             (search-forward-regexp "^
+?$")
              (skip-chars-forward "[:blank:]\n")
              (delete-region (point-min) (point))
              (unless (eobp) (if (eq reader t) t (funcall reader)))))))
@@ -1313,7 +1314,8 @@ Letters do not insert themselves; instead, they are commands.
   (add-hook 'tabulated-list-revert-hook 'paradox--commit-list-update-entries)
   (tabulated-list-init-header))
 
-(define-key paradox-commit-list-mode-map "" #'paradox-commit-list-visit-commit)
+(define-key paradox-commit-list-mode-map "
+" #'paradox-commit-list-visit-commit)
 (define-key paradox-commit-list-mode-map "p" #'paradox-previous-commit)
 (define-key paradox-commit-list-mode-map "n" #'paradox-next-commit)
 


### PR DESCRIPTION
- Version numbers are mandatory
- Shouldn't depend on built-in packages which aren't available separately for older Emacsen
