### PR TITLE
Clean up dependencies

### DIFF
--- a/paradox.el
+++ b/paradox.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/Malabarba/paradox
 ;; Version: 2.4
 ;; Keywords: package packages
-;; Package-Requires: ((emacs "24.4") (seq "1.7") (cl-lib "0.5") (json "1.3") (let-alist "1.0.3") (spinner "1.4") (hydra "0.13.2"))
+;; Package-Requires: ((emacs "24.4") (seq "1.7") (let-alist "1.0.3") (spinner "1.4") (hydra "0.13.2"))
 ;; Prefix: paradox
 ;; Separator: -
 


### PR DESCRIPTION
Emacs 24.4 bundles cl-lib 1.0 and json 1.4.