### PR TITLE
Invert :inherit order for paradox-mode-line-face

### DIFF
--- a/paradox-menu.el
+++ b/paradox-menu.el
@@ -83,9 +83,9 @@
   :package-version '(paradox . "1.2.3"))
 
 (defface paradox-mode-line-face
-  '((t :inherit (mode-line-buffer-id font-lock-keyword-face)
+  '((t :inherit (font-lock-keyword-face mode-line-buffer-id)
        :weight normal))
-  "Face used on the package's name."
+  "Face used on mode line statuses."
   :group 'paradox)
 (defface paradox-name-face
   '((t :inherit link))


### PR DESCRIPTION
Hi! 

I've started using a dark theme which adds a foreground to mode-line-buffer-id; this broke the overall look of the Paradox mode line, i.e. the whole mode line matched mode-line-buffer-id, and statuses were no longer highlighted.

Making paradox-mode-line-face inherit from font-lock-keyword-face first, *then* mode-line-buffer-id restored the original look. What this means in practice is that any attribute defined in font-lock-keyword-face will have precedence over what is defined in mode-line-buffer-id. 

I believe this should work out, since AFAIK themes only ever define a foreground and maybe a weight for font-lock-keyword-face.

I tried setting up Cask and EVM to run tests on my machine, but I could not figure out a way to tell EVM to stop trying to run 64-bit binaries on my 32-bit machine.


Anyway, thank you for Paradox! Even though Emacs 25.1 improved the default package manager, Paradox's "filter upgrades" and "view commit list" options remain killer features for me.
