### PR TITLE
No longer provide a feature in test-helper.el

### DIFF
--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -18,5 +18,4 @@
 (undercover "*.el")
 (require 'paradox)
 
-(provide 'test-helper)
 ;;; test-helper.el ends here


### PR DESCRIPTION
The file isn't a library intended to be loaded with `require`.
Instead `ert-runner` loads it using `load`.  Other packages that
use `ert-runner` also come with a file named test-helper.el and
unfortunately many of those also provide `test-helper`, which
leads to conflicts.

Fixes #135.

One test fails for me, but it also fails without this change.