### PR TITLE
Relocated repos

### DIFF
--- a/paradox-github.el
+++ b/paradox-github.el
@@ -225,7 +225,9 @@ Leave point at the return code on the first line."
     (`200 t)   ;; OK, with content.
     ;; I'll implement redirection if anyone ever reports this.
     ;; For now, I haven't found a place where it's used.
-    ((or `301 `302 `303 `304 `305 `306 `307)
+    (`301
+     (search-forward "HTTP/1.1 ") t)
+    ((or `302 `303 `304 `305 `306 `307)
      (paradox--github-report "Redirect received:\n\n" (buffer-string))
      ;; (message "Received a redirect reply, please file a bug report (M-x `paradox-bug-report')")
      nil)

--- a/paradox-github.el
+++ b/paradox-github.el
@@ -289,7 +289,7 @@ value."
                (set-process-sentinel
                 (apply #'start-process "paradox-github"
                        (generate-new-buffer "*Paradox http*")
-                       "curl" "-s" "-i" "-d" "" "-X" ,method ,action
+                       "curl" "-L" "-s" "-i" "-d" "" "-X" ,method ,action
                        (when (stringp paradox-github-token)
                          (list "-u" (concat paradox-github-token ":x-oauth-basic"))))
                 ,call-name)
@@ -298,7 +298,7 @@ value."
            ;; Make the request.
            (condition-case nil
                (apply #'call-process
-                      "curl" nil t nil "-s" "-i" "-d" "" "-X" ,method ,action
+                      "curl" nil t nil "-L" "-s" "-i" "-d" "" "-X" ,method ,action
                       (when (stringp paradox-github-token)
                         (list "-u" (concat paradox-github-token ":x-oauth-basic"))))
              (error ,unwind-form))


### PR DESCRIPTION
Tue Aug  7 19:50:58 BST 2018

Code to process 301 return codes (for relocated repos).

<details>
<summary>Emacs test</summary>

```
ELISP> (load "/usr/local/src/paradox/paradox-github.el")
t
ELISP> (paradox--github-action "repos/capitaomorte/sly" :reader #'json-read)
((id . 17603517)
 (node_id . "MDEwOlJlcG9zaXRvcnkxNzYwMzUxNw==")
 (name . "sly")
 (full_name . "joaotavora/sly")
 (owner
  (login . "joaotavora")
  (id . 387011)
  (node_id . "MDQ6VXNlcjM4NzAxMQ==")
  (avatar_url . "https://avatars0.githubusercontent.com/u/387011?v=4")
  (gravatar_id . "")
  (url . "https://api.github.com/users/joaotavora")
  (html_url . "https://github.com/joaotavora")
  (followers_url . "https://api.github.com/users/joaotavora/followers")
  (following_url . "https://api.github.com/users/joaotavora/following{/other_user}")
  (gists_url . "https://api.github.com/users/joaotavora/gists{/gist_id}")
  (starred_url . "https://api.github.com/users/joaotavora/starred{/owner}{/repo}")
  (subscriptions_url . "https://api.github.com/users/joaotavora/subscriptions")
  (organizations_url . "https://api.github.com/users/joaotavora/orgs")
  (repos_url . "https://api.github.com/users/joaotavora/repos")
  (events_url . "https://api.github.com/users/joaotavora/events{/privacy}")
  (received_events_url . "https://api.github.com/users/joaotavora/received_events")
  (type . "User")
  (site_admin . :json-false))
 (private . :json-false)
 (html_url . "https://github.com/joaotavora/sly")
 (description . "Sylvester the Cat's Common Lisp IDE")
 (fork . :json-false)
 (url . "https://api.github.com/repos/joaotavora/sly")
 (forks_url . "https://api.github.com/repos/joaotavora/sly/forks")
 (keys_url . "https://api.github.com/repos/joaotavora/sly/keys{/key_id}")
 (collaborators_url . "https://api.github.com/repos/joaotavora/sly/collaborators{/collaborator}")
 (teams_url . "https://api.github.com/repos/joaotavora/sly/teams")
 (hooks_url . "https://api.github.com/repos/joaotavora/sly/hooks")
 (issue_events_url . "https://api.github.com/repos/joaotavora/sly/issues/events{/number}")
 (events_url . "https://api.github.com/repos/joaotavora/sly/events")
 (assignees_url . "https://api.github.com/repos/joaotavora/sly/assignees{/user}")
 (branches_url . "https://api.github.com/repos/joaotavora/sly/branches{/branch}")
 (tags_url . "https://api.github.com/repos/joaotavora/sly/tags")
 (blobs_url . "https://api.github.com/repos/joaotavora/sly/git/blobs{/sha}")
 (git_tags_url . "https://api.github.com/repos/joaotavora/sly/git/tags{/sha}")
 (git_refs_url . "https://api.github.com/repos/joaotavora/sly/git/refs{/sha}")
 (trees_url . "https://api.github.com/repos/joaotavora/sly/git/trees{/sha}")
 (statuses_url . "https://api.github.com/repos/joaotavora/sly/statuses/{sha}")
 (languages_url . "https://api.github.com/repos/joaotavora/sly/languages")
 (stargazers_url . "https://api.github.com/repos/joaotavora/sly/stargazers")
 (contributors_url . "https://api.github.com/repos/joaotavora/sly/contributors")
 (subscribers_url . "https://api.github.com/repos/joaotavora/sly/subscribers")
 (subscription_url . "https://api.github.com/repos/joaotavora/sly/subscription")
 (commits_url . "https://api.github.com/repos/joaotavora/sly/commits{/sha}")
 (git_commits_url . "https://api.github.com/repos/joaotavora/sly/git/commits{/sha}")
 (comments_url . "https://api.github.com/repos/joaotavora/sly/comments{/number}")
 (issue_comment_url . "https://api.github.com/repos/joaotavora/sly/issues/comments{/number}")
 (contents_url . "https://api.github.com/repos/joaotavora/sly/contents/{+path}")
 (compare_url . "https://api.github.com/repos/joaotavora/sly/compare/{base}...{head}")
 (merges_url . "https://api.github.com/repos/joaotavora/sly/merges")
 (archive_url . "https://api.github.com/repos/joaotavora/sly/{archive_format}{/ref}")
 (downloads_url . "https://api.github.com/repos/joaotavora/sly/downloads")
 (issues_url . "https://api.github.com/repos/joaotavora/sly/issues{/number}")
 (pulls_url . "https://api.github.com/repos/joaotavora/sly/pulls{/number}")
 (milestones_url . "https://api.github.com/repos/joaotavora/sly/milestones{/number}")
 (notifications_url . "https://api.github.com/repos/joaotavora/sly/notifications{?since,all,participating}")
 (labels_url . "https://api.github.com/repos/joaotavora/sly/labels{/name}")
 (releases_url . "https://api.github.com/repos/joaotavora/sly/releases{/id}")
 (deployments_url . "https://api.github.com/repos/joaotavora/sly/deployments")
 (created_at . "2014-03-10T18:24:08Z")
 (updated_at . "2018-08-07T13:46:07Z")
 (pushed_at . "2018-08-06T20:26:21Z")
 (git_url . "git://github.com/joaotavora/sly.git")
 (ssh_url . "git@github.com:joaotavora/sly.git")
 (clone_url . "https://github.com/joaotavora/sly.git")
 (svn_url . "https://github.com/joaotavora/sly")
 (homepage . "")
 (size . 23974)
 (stargazers_count . 338)
 (watchers_count . 338)
 (language . "Common Lisp")
 (has_issues . t)
 (has_projects . t)
 (has_downloads . t)
 (has_wiki . t)
 (has_pages . t)
 (forks_count . 27)
 (mirror_url)
 (archived . :json-false)
 (open_issues_count . 29)
 (license)
 (forks . 27)
 (open_issues . 29)
 (watchers . 338)
 (default_branch . "master")
 (network_count . 27)
 (subscribers_count . 35))

ELISP> 
ELISP> (paradox-fetch-star-count "capitaomorte/sly")
338 (#o522, #x152)
ELISP>
```
<hr>
</details>