### PR TITLE
Fix "Invalid face reference" warnings for custom-button-mouse

### DIFF
--- a/paradox-menu.el
+++ b/paradox-menu.el
@@ -23,6 +23,7 @@
 
 ;;; Code:
 (require 'cl-lib)
+(require 'cus-edit)
 (require 'package)
 (require 'subr-x)
 (require 'hydra)


### PR DESCRIPTION
Hi!

Here is a minor hiccup I never noticed until I looked at the
`*Messages*` buffer.  When hovering over the "homepage" buttons, the
following errors show up in `*Messages*`:

    Invalid face reference: custom-button-mouse

I believe this is due to this face being defined in `cus-edit.el`,
which is not `require`d by Paradox.  This is a bit tricky to reproduce
with `emacs -Q`:

``` elisp
(require 'package)
(setq package-load-list '((paradox t) (spinner t) (hydra t)))

;; Set those variables, otherwise package.el and paradox-github.el
;; customize them, which IIUC loads cus-edit.el as a side-effect. 
(setq package-selected-packages '(paradox spinner hydra))
(setq paradox-github-token t)

(package-initialize)
```

Then:

- `M-x paradox-list-packages`
- hover over the homepage buttons
    - the `custom-button-mouse` face does not show up
    - the `*Messages*` buffer gets filled with "Invalid face
      reference" warnings
- `M-: (require 'cus-edit)`
- hover over the homepage buttons
    - the face shows up correctly

I hope I am interpreting the symptoms correctly, and that the fix is
also adequate.
