### PR TITLE
Use button.el API properly

### DIFF
--- a/paradox-commit-list.el
+++ b/paradox-commit-list.el
@@ -81,6 +81,13 @@ nil means `default'.")
 (defvar-local paradox--package-tag-commit-alist nil
   "Alist of (COMMIT-SHA . TAG) for this package's repo.")
 
+(define-button-type 'paradox-commit
+  'action      #'paradox-commit-list-visit-commit
+  'follow-link t)
+
+;; Use `font-lock-face' on creation instead.
+(button-type-put 'paradox-commit 'face nil)
+
 
 ;;; Functions
 (defun paradox--get-tag-commit-alist (repo)
@@ -150,11 +157,10 @@ nil means `default'.")
              ,@x)
            ;; The actual displayed data
            (vector
-            (propertize (format-time-string paradox-date-format date)
-                        'button t
-                        'follow-link t
-                        'action 'paradox-commit-list-visit-commit
-                        'face (or paradox--commit-message-face 'link))
+            (make-text-button
+             (format-time-string paradox-date-format date) nil
+             'type           'paradox-commit
+             'font-lock-face (or paradox--commit-message-face 'button))
             (concat (if (> cc 0)
                         (propertize (format "(%s comments) " cc)
                                     'face 'font-lock-function-name-face)

--- a/paradox-menu.el
+++ b/paradox-menu.el
@@ -730,7 +730,7 @@ Status:  _i_nstalled _a_vailable _d_ependency _b_uilt-in
   "Move to previous entry, which might not be the previous line.
 With prefix N, move to the N-th previous entry."
   (interactive "p")
-  (paradox-next-entry (- n))
+  (paradox-next-entry (- (prefix-numeric-value n)))
   (forward-line 0)
   (forward-button 1))
 
@@ -738,9 +738,10 @@ With prefix N, move to the N-th previous entry."
   "Move to next entry, which might not be the next line.
 With prefix N, move to the N-th next entry."
   (interactive "p")
-  (dotimes (_ (abs n))
-    (let ((d (cl-signum n)))
-      (forward-line (if (> n 0) 1 0))
+  (setq n (prefix-numeric-value n))
+  (let ((d (cl-signum n)))
+    (dotimes (_ (abs n))
+      (forward-line (max d 0))
       (if (eobp) (forward-line -1))
       (forward-button d))))
 

--- a/paradox-menu.el
+++ b/paradox-menu.el
@@ -193,6 +193,19 @@ This button takes you to the package's homepage."
 
 (defvar paradox--commit-list-buffer "*Package Commit List*")
 
+(define-button-type 'paradox-name
+  'action      #'package-menu-describe-package
+  'follow-link t)
+
+(define-button-type 'paradox-homepage
+  'action      #'paradox-menu-visit-homepage
+  'follow-link t
+  'mouse-face  'custom-button-mouse)
+
+;; Use `font-lock-face' on creation instead.
+(button-type-put 'paradox-name     'face nil)
+(button-type-put 'paradox-homepage 'face nil)
+
 
 ;;; Building the packages buffer.
 (defun paradox-refresh-upgradeable-packages ()
@@ -224,26 +237,22 @@ Return (PKG-DESC [STAR NAME VERSION STATUS DOC])."
         (push (cons :stars counts) (package-desc-extras pkg-desc))))
     (list pkg-desc
           `[,(concat
-              (truncate-string-to-width
-               (propertize name
-                           'font-lock-face 'paradox-name-face
-                           'button t
-                           'follow-link t
-                           'help-echo (format "Package: %s" name)
-                           'package-desc pkg-desc
-                           'action 'package-menu-describe-package)
-               (- paradox-column-width-package button-length) 0 nil t)
+              (make-text-button
+               (truncate-string-to-width
+                name (- paradox-column-width-package button-length) 0 nil t)
+               nil
+               'type           'paradox-name
+               'font-lock-face 'paradox-name-face
+               'help-echo      (concat "Package: " name)
+               'package-desc   pkg-desc)
               (when (and paradox-use-homepage-buttons url)
                 (make-string (max 0 (- paradox-column-width-package name-length button-length)) ?\s))
               (when (and paradox-use-homepage-buttons url)
-                (propertize paradox-homepage-button-string
-                            'font-lock-face 'paradox-homepage-button-face
-                            'mouse-face 'custom-button-mouse
-                            'help-echo (format "Visit %s" url)
-                            'button t
-                            'follow-link t
-                            'keymap '(keymap (mouse-2 . push-button))
-                            'action #'paradox-menu-visit-homepage)))
+                (make-text-button
+                 (copy-sequence paradox-homepage-button-string) nil
+                 'type           'paradox-homepage
+                 'font-lock-face 'paradox-homepage-button-face
+                 'help-echo      (format "Visit %s" url))))
             ,(propertize (package-version-join
                           (package-desc-version pkg-desc))
                          'font-lock-face face)
@@ -752,9 +761,8 @@ With prefix N, move to the N-th previous package instead."
 (defun paradox-push-button ()
   "Push button under point, or describe package."
   (interactive)
-  (if (get-text-property (point) 'action)
-      (call-interactively 'push-button)
-    (call-interactively 'package-menu-describe-package)))
+  (or (push-button)
+      (call-interactively #'package-menu-describe-package)))
 
 (defvar paradox--key-descriptors
   '(("next," "previous," "install," "delete," ("execute," . 1) "refresh," "help")


### PR DESCRIPTION
Do not try to manipulate arbitrary propertized text using `button.el` functions such as `forward-button` et al.  Instead, declare our own button types and create them using the `button.el` API.

This PR also includes a separate commit which fixes a minor bug in `paradox-next-entry` and `paradox-previous-entry` where their optional argument can be `nil` when called from Lisp.

Fixes #170.

**N.B.:** I have only tested this PR interactively, and have not run the test suite, as I would rather not have to download and run arbitrary executables from the web.