### PR TITLE
Update menu refresh functions

### DIFF
--- a/paradox-menu.el
+++ b/paradox-menu.el
@@ -524,6 +524,11 @@ Letters do not insert themselves; instead, they are commands.
   ;; (add-hook 'tabulated-list-revert-hook #'paradox--refresh-remote-data nil t)
   (add-hook 'tabulated-list-revert-hook #'paradox--update-mode-line 'append t)
   (tabulated-list-init-header)
+  (setq revert-buffer-function 'package-menu--refresh-contents)
+  (setf imenu-prev-index-position-function
+        #'package--imenu-prev-index-position-function)
+  (setf imenu-extract-index-name-function
+        #'package--imenu-extract-index-name-function)
   ;; We need package-menu-mode to be our parent, otherwise some
   ;; commands throw errors.  But we can't actually derive from it,
   ;; otherwise its initialization will screw up the header-format.  So

--- a/paradox-menu.el
+++ b/paradox-menu.el
@@ -524,11 +524,12 @@ Letters do not insert themselves; instead, they are commands.
   ;; (add-hook 'tabulated-list-revert-hook #'paradox--refresh-remote-data nil t)
   (add-hook 'tabulated-list-revert-hook #'paradox--update-mode-line 'append t)
   (tabulated-list-init-header)
-  (setq revert-buffer-function 'package-menu--refresh-contents)
-  (setf imenu-prev-index-position-function
-        #'package--imenu-prev-index-position-function)
-  (setf imenu-extract-index-name-function
-        #'package--imenu-extract-index-name-function)
+  (when (fboundp 'package-menu--refresh-contents)
+    (setq revert-buffer-function 'package-menu--refresh-contents)
+    (setf imenu-prev-index-position-function
+          #'package--imenu-prev-index-position-function)
+    (setf imenu-extract-index-name-function
+          #'package--imenu-extract-index-name-function))
   ;; We need package-menu-mode to be our parent, otherwise some
   ;; commands throw errors.  But we can't actually derive from it,
   ;; otherwise its initialization will screw up the header-format.  So


### PR DESCRIPTION
Set 'revert-buffer-function' like in in new versions of (as of emacs-27)  'package-menu-mode'.

* paradox-menu.el: backport some initialisation functions from 'package-menu-mode'.