### PR TITLE
Add paradox-less-verbose to avoid startup messages

### DIFF
--- a/paradox-core.el
+++ b/paradox-core.el
@@ -78,6 +78,11 @@ ELLIPSIS are passed to `truncate-string-to-width'."
 
 ;;; Overriding definitions
 (defvar paradox--backups nil)
+(defcustom paradox-less-verbose nil
+  "If non-nil, don't display messages about overriding definitions when enabling."
+  :type 'boolean
+  :package-version '(paradox . "2.5.4")
+  :group 'paradox-execute)
 
 (defun paradox--core-enable ()
   "Enable core features."
@@ -101,7 +106,7 @@ ELLIPSIS are passed to `truncate-string-to-width'."
 Record that in `paradox--backups', but do nothing if
 `paradox--backups' reports that it is already overriden."
   (unless (memq sym paradox--backups)
-    (message "Overriding %s with %s" sym newdef)
+    (unless paradox-less-verbose (message "Overriding %s with %s" sym newdef))
     (advice-add sym :override newdef '((name . :paradox-override)))
     (add-to-list 'paradox--backups sym)))
 


### PR DESCRIPTION
`paradox--override-definition` (from paradox-core.el) is called four times on `paradox-enable`.  This would add `paradox-less-verbose` to optionally disable those notices.

----

Not entirely sure if this is desirable for anyone but me, given the minimal impact, but figured I'd put it up in case others cared.  In theory it could be used elsewhere?