### PR TITLE
Add header padding to archive column

### DIFF
--- a/paradox-menu.el
+++ b/paradox-menu.el
@@ -477,7 +477,7 @@ used to define keywords."
   "List containing archive to be used as part of the entry."
   (when (cdr package-archives)
     (list (list "Archive"
-                (apply 'max (mapcar 'length (mapcar 'car package-archives)))
+                (max 8 (1+ (apply 'max (mapcar 'length (mapcar 'car package-archives)))))
                 'package-menu--archive-predicate))))
 
 (add-hook 'paradox-menu-mode-hook 'paradox-refresh-upgradeable-packages)


### PR DESCRIPTION
If both the stars and download columns are turned off, and the longest archive name is still shorter than "Archive", then the Archive column will have no padding on the right seperating it from the Description column. This PR takes the larger of the length of "Archive" + 1 and the length of the longest archive name + 1 to be the width of the Archive column.